### PR TITLE
Fix repository name case in Antora playbook URLs

### DIFF
--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -1,6 +1,6 @@
 site:
   title: daily-standapp
-  url: https://michalharakal.github.io/Daily-StandAPP
+  url: https://michalharakal.github.io/dAily-StandAPP
   start_page: daily-standapp::index.adoc
   keys:
     google_analytics: ''
@@ -9,7 +9,7 @@ content:
   - url: ../                 # The current folder is a git repo
     branches: HEAD         # "HEAD" uses whichever branch is currently checked out
     start_path: docs/src/docs
-    edit_url: 'https://github.com/michalharakal/Daily-StandAPP/{path}'
+    edit_url: 'https://github.com/michalharakal/dAily-StandAPP/{path}'
 
 ui:
   bundle:


### PR DESCRIPTION
The site URL and edit URL used 'Daily-StandAPP' but the actual repository name is 'dAily-StandAPP'. This case mismatch would cause GitHub Pages to fail to resolve correctly.