### PR TITLE
Fix JLama backend for fair benchmark comparison

### DIFF
--- a/benchmark/src/jvmMain/kotlin/de/jug_da/standapp/benchmark/Main.kt
+++ b/benchmark/src/jvmMain/kotlin/de/jug_da/standapp/benchmark/Main.kt
@@ -22,6 +22,7 @@ import java.io.File
  * - BENCH_CLOUD_MODEL       — cloud model name (default: gpt-4o-mini)
  * - BENCH_CLOUD_API_KEY     — optional cloud Bearer token (falls back to OPENAI_API_KEY)
  * - MCP_LLM_MODEL_PATH      — GGUF model path for SKAINET backend
+ * - BENCH_JLAMA_MODEL       — HuggingFace model ID for JLAMA backend (default: mistralai/Mistral-7B-Instruct-v0.3)
  */
 fun main() {
     val benchDir = File(System.getenv("BENCH_DIR") ?: "bench")
@@ -50,6 +51,7 @@ fun main() {
     val cloudModel = System.getenv("BENCH_CLOUD_MODEL") ?: "gpt-4o-mini"
     val cloudApiKey = System.getenv("BENCH_CLOUD_API_KEY") ?: System.getenv("OPENAI_API_KEY")
     val modelPath = System.getenv("MCP_LLM_MODEL_PATH") ?: ""
+    val jlamaModel = System.getenv("BENCH_JLAMA_MODEL") ?: ""
     val outputDir = File(System.getenv("BENCH_OUTPUT_DIR") ?: "benchmark-results")
 
     val requestedBackends = System.getenv("BENCH_BACKENDS")
@@ -65,6 +67,10 @@ fun main() {
         } else {
             println("WARN: Skipping SKAINET — MCP_LLM_MODEL_PATH not set")
         }
+    }
+
+    if (requestedBackends == null || "JLAMA" in requestedBackends) {
+        backends["JLAMA"] = LLMBackendType.JLAMA to LLMConfig(modelPath = jlamaModel)
     }
 
     if (requestedBackends == null || "REST_API" in requestedBackends) {

--- a/llm/src/jvmMain/kotlin/de/jug_da/standapp/llm/JLamaService.kt
+++ b/llm/src/jvmMain/kotlin/de/jug_da/standapp/llm/JLamaService.kt
@@ -1,0 +1,57 @@
+package de.jug_da.standapp.llm
+
+import com.github.tjake.jlama.model.AbstractModel
+import com.github.tjake.jlama.model.ModelSupport
+import com.github.tjake.jlama.model.functions.Generator
+import com.github.tjake.jlama.safetensors.DType
+import com.github.tjake.jlama.safetensors.prompt.PromptContext
+import com.github.tjake.jlama.util.Downloader
+import java.util.*
+import java.util.function.BiConsumer
+
+
+class JLamaService private constructor(private val m: AbstractModel) : LLMService {
+    override suspend fun generate(
+        prompt: String,
+        maxTokens: Int,
+        temperature: Float,
+        topP: Float
+    ): String {
+        val systemPrompt = "You are a helpful assistant that creates concise standup summaries from git commit data."
+
+        val ctx = if (m.promptSupport().isPresent) {
+            m.promptSupport()
+                .get()
+                .builder()
+                .addSystemMessage(systemPrompt)
+                .addUserMessage(prompt)
+                .build();
+        } else {
+            PromptContext.of(prompt);
+        }
+        val r: Generator.Response =
+            m.generate(UUID.randomUUID(), ctx, temperature, maxTokens, BiConsumer { s: String?, f: Float? -> })
+        return r.responseText
+    }
+
+    companion object {
+        private const val DEFAULT_MODEL = "mistralai/Mistral-7B-Instruct-v0.3"
+
+        fun create(
+            modelPath: String,
+            tokenizerPath: String,
+            maxSequenceLength: Int = 512
+        ): JLamaService {
+            val model = modelPath.ifBlank { DEFAULT_MODEL }
+            val workingDirectory = "./models"
+
+            // Downloads the model or just returns the local path if it's already downloaded
+            val localModelPath = Downloader(workingDirectory, model).huggingFaceModel()
+
+            // Loads the quantized model and specified use of quantized memory
+            val llm = ModelSupport.loadModel(localModelPath, DType.F32, DType.I8)
+
+            return JLamaService(llm)
+        }
+    }
+}


### PR DESCRIPTION
Remove 200-char prompt truncation, forward maxTokens parameter instead of hardcoding 100, use standup-assistant system prompt matching other backends, and make HuggingFace model ID configurable via BENCH_JLAMA_MODEL env var.